### PR TITLE
fix(aside): adjust overflow and line clamp for text

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -558,6 +558,12 @@ footer {
             font-weight 200ms ease-in-out;
           width: fit-content;
           user-select: none;
+          overflow: hidden;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 1;
+          line-clamp: 1;
+
           &:hover,
           &:focus {
             box-shadow: none;


### PR DESCRIPTION
# Before
<img width="460" height="477" alt="Screenshot 2026-03-24 at 5 13 42 PM" src="https://github.com/user-attachments/assets/acab8e78-011a-42ae-80cf-2a24085624c1" />

# After
<img width="460" height="477" alt="Screenshot 2026-03-24 at 5 14 14 PM" src="https://github.com/user-attachments/assets/bc402db9-3735-4940-9252-d8e55bc8d4d7" />

